### PR TITLE
reinstating the branch selector to ensure the publish doesn't run for…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,9 @@ workflows:
       - publish:
           context: boxhead-builds
           filters:
-#            branches:
-#              ignore: /.*/
+            branches:
+              ignore: /.*/
             # only act on version tags
             tags:
-              only: /^release-[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^release.*/
 #              only: /^release-(?:[0-9]+\.){2}[0-9]+$/


### PR DESCRIPTION
… all branches and made the regex for the tag filter a lot more loose to just match on the release tag prefix