### PR TITLE
Automated fix for Gradle 9.4.0 update failure

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzDefinitionTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzDefinitionTask.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
+@org.gradle.api.tasks.UntrackedTask(because = "Not cacheable")
 public class ClusterfuzzDefinitionTask extends DefaultTask {
 
     public static final String NAME = ClusterfuzzPlugin.CLUSTERFUZZ_PLUGIN_NAME + "Definition"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteCorpusTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteCorpusTask.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
+@org.gradle.api.tasks.UntrackedTask(because = "Not cacheable")
 public class ClusterfuzzWriteCorpusTask extends DefaultTask {
 
     public static final String NAME = ClusterfuzzPlugin.CLUSTERFUZZ_PLUGIN_NAME + "Corpus"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteRunScriptTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteRunScriptTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.clusterfuzz
 
@@ -9,6 +9,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
+@org.gradle.api.tasks.UntrackedTask(because = "Not cacheable")
 public class ClusterfuzzWriteRunScriptTask extends DefaultTask {
 
     public static final String NAME = ClusterfuzzPlugin.CLUSTERFUZZ_PLUGIN_NAME + "Runscript"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteTestScriptsTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/clusterfuzz/ClusterfuzzWriteTestScriptsTask.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
+@org.gradle.api.tasks.UntrackedTask(because = "Not cacheable")
 public class ClusterfuzzWriteTestScriptsTask extends DefaultTask {
 
     public static final String NAME = ClusterfuzzPlugin.CLUSTERFUZZ_PLUGIN_NAME + "Scripts"
@@ -57,7 +58,8 @@ public class ClusterfuzzWriteTestScriptsTask extends DefaultTask {
 
     private groovy.text.Template template
 
-    private synchronized groovy.text.Template getTemplate() {
+    @org.gradle.api.tasks.Internal
+    public synchronized groovy.text.Template getTemplate() {
         if (template == null) {
             def templateContent = IOUtils.resourceToString('/templates/test_template.sh', Charset.forName("UTF-8"))
             def engine = new groovy.text.SimpleTemplateEngine()


### PR DESCRIPTION
Fixes task validation errors caused by the upgrade to Gradle 9.4.0, which enforces stricter checks on task input/output annotations.

Specifically, it marks the following tasks as untracked to resolve the missing cacheability annotations error:
* `ClusterfuzzDefinitionTask`
* `ClusterfuzzWriteCorpusTask`
* `ClusterfuzzWriteRunScriptTask`
* `ClusterfuzzWriteTestScriptsTask`

And it adds `@Internal` to the `getTemplate()` getter in `ClusterfuzzWriteTestScriptsTask` to fix the missing input/output annotation error for the property.

---
*PR created automatically by Jules for task [4477534190399813482](https://jules.google.com/task/4477534190399813482) started by @boxheed*